### PR TITLE
Fix #26, change symbolic links to files

### DIFF
--- a/autopair.plugin.zsh
+++ b/autopair.plugin.zsh
@@ -1,1 +1,4 @@
-autopair.zsh
+# <https://github.com/zdharma-continuum/Zsh-100-Commits-Club/blob/master/Zsh-Plugin-Standard.adoc>
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+source "${0:A:h}/autopair.zsh"

--- a/zsh-autopair.plugin.zsh
+++ b/zsh-autopair.plugin.zsh
@@ -1,1 +1,4 @@
-autopair.zsh
+# <https://github.com/zdharma-continuum/Zsh-100-Commits-Club/blob/master/Zsh-Plugin-Standard.adoc>
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+source "${0:A:h}/autopair.zsh"


### PR DESCRIPTION
In windows, user cannot create symbolic link without administrator privilege or
enable the developer mode. So change symbolic links to normal files should be
convenient to clone this project in windows.
